### PR TITLE
Allow read-only queries that do not start with SELECT keyword

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "cryptography>=41.0.0",
     "mcp",
     "anyio>=3.7.1",
+    "sqlglot>=11.5.5"
 ]
 
 [project.scripts]

--- a/uv.lock
+++ b/uv.lock
@@ -270,6 +270,7 @@ dependencies = [
     { name = "pydantic" },
     { name = "python-dotenv" },
     { name = "snowflake-connector-python" },
+    { name = "sqlglot" },
 ]
 
 [package.optional-dependencies]
@@ -290,6 +291,7 @@ requires-dist = [
     { name = "python-dotenv", specifier = ">=1.0.0" },
     { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.1.0" },
     { name = "snowflake-connector-python", specifier = ">=3.8.0" },
+    { name = "sqlglot", specifier = ">=11.5.5" },
 ]
 provides-extras = ["dev"]
 
@@ -571,6 +573,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/e8/c4/ba2f8066cceb6f23394729afe52f3bf7adec04bf9ed2c820b39e19299111/sortedcontainers-2.4.0.tar.gz", hash = "sha256:25caa5a06cc30b6b83d11423433f65d1f9d76c4c6a0c90e3379eaa43b9bfdb88", size = 30594 }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/32/46/9cb0e58b2deb7f82b84065f37f3bffeb12413f947f9388e4cac22c4621ce/sortedcontainers-2.4.0-py2.py3-none-any.whl", hash = "sha256:a163dcaede0f1c021485e957a39245190e74249897e2ae4b2aa38595db237ee0", size = 29575 },
+]
+
+[[package]]
+name = "sqlglot"
+version = "26.11.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/3e/5b873e01d16cf1efa1db1695f9587c10c4dda558628a127d0d453a1ab4e5/sqlglot-26.11.1.tar.gz", hash = "sha256:e1e7c9bbabc9f8cefa35aa07daf3ac0048dacd9bc3131225785596beb0d844d6", size = 5335079 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a6/01/b63c66b6444f3bf92a0c4c9b166602bc0e1a5b3b4677138222bf9f1f6dbd/sqlglot-26.11.1-py3-none-any.whl", hash = "sha256:5659fb46937ed89da6854e30eb318f57110f5526ef555407a2bf8f714e70496d", size = 453296 },
 ]
 
 [[package]]


### PR DESCRIPTION
- I was finding it a bit restrictive to disallow any query that doesn't start with "SELECT" because it is often useful to start a select statement with a CTE ("WITH"), and to occasionally use SHOW or DESCRIBE

- therefore, in the handler for the query tool, instead of disallowing any query that doesn't start with the SELECT keyword, parse the query into its component statements and disallow if any of those component statements is a non-read-only operation

- add a dependency on sqlglot, for parsing the query