### PR TITLE
Ensure trailing semicolon is removed before appending LIMIT clause in handle_execute_query

### DIFF
--- a/mcp_server_snowflake/main.py
+++ b/mcp_server_snowflake/main.py
@@ -380,7 +380,9 @@ async def handle_execute_query(
         # Ensure the query has a LIMIT clause to prevent large result sets
         # Parse the query to check if it already has a LIMIT
         if "LIMIT " not in query.upper():
-            query = f"{query} LIMIT {limit_rows}"
+            # Remove any trailing semicolon before adding the LIMIT clause
+            query = query.rstrip().rstrip(';')
+            query = f"{query} LIMIT {limit_rows};"
 
         # Execute the query
         cursor = conn.cursor()


### PR DESCRIPTION
I encountered an error when the MCP server called the execute_query method. The issue was caused by a trailing semicolon (;) being added to the query before concatenating the LIMIT clause, resulting in a syntax error.

This fix ensures that any trailing semicolon is removed before appending the LIMIT clause to prevent such errors.