### PR TITLE
Support externalbrowser auth and utilize connection pooling with Snowflake 

### DIFF
--- a/.env.browser.example
+++ b/.env.browser.example
@@ -13,3 +13,7 @@ SNOWFLAKE_ROLE=your_role
 
 # Note: No private key path is needed for external browser authentication
 # A browser window will open automatically for login when you start the server
+
+# Connection Pooling Settings
+# Time interval in hours between automatic connection refreshes (default: 8)
+SNOWFLAKE_CONN_REFRESH_HOURS=8

--- a/.env.browser.example
+++ b/.env.browser.example
@@ -1,0 +1,15 @@
+# Snowflake Connection Parameters - External Browser Authentication Example
+
+# Authentication Type
+SNOWFLAKE_AUTH_TYPE=external_browser
+
+# Connection Parameters
+SNOWFLAKE_ACCOUNT=your_account_id.your_region
+SNOWFLAKE_USER=your_regular_username
+SNOWFLAKE_WAREHOUSE=your_warehouse
+SNOWFLAKE_DATABASE=your_database
+SNOWFLAKE_SCHEMA=your_schema
+SNOWFLAKE_ROLE=your_role
+
+# Note: No private key path is needed for external browser authentication
+# A browser window will open automatically for login when you start the server

--- a/.env.example
+++ b/.env.example
@@ -1,8 +1,0 @@
-# Snowflake Connection Parameters
-SNOWFLAKE_ACCOUNT=your_account_id.your_region
-SNOWFLAKE_USER=your_service_account_username
-SNOWFLAKE_PRIVATE_KEY_PATH=/path/to/your/private_key.p8
-SNOWFLAKE_WAREHOUSE=your_warehouse
-SNOWFLAKE_DATABASE=your_database
-SNOWFLAKE_SCHEMA=your_schema
-SNOWFLAKE_ROLE=your_role

--- a/.env.private_key.example
+++ b/.env.private_key.example
@@ -1,0 +1,15 @@
+# Snowflake Connection Parameters - Private Key Authentication Example
+
+# Authentication Type
+SNOWFLAKE_AUTH_TYPE=private_key
+
+# Connection Parameters
+SNOWFLAKE_ACCOUNT=your_account_id.your_region
+SNOWFLAKE_USER=your_service_account_username
+SNOWFLAKE_WAREHOUSE=your_warehouse
+SNOWFLAKE_DATABASE=your_database
+SNOWFLAKE_SCHEMA=your_schema
+SNOWFLAKE_ROLE=your_role
+
+# Private Key Authentication Parameters
+SNOWFLAKE_PRIVATE_KEY_PATH=/absolute/path/to/your/private_key.p8

--- a/.env.private_key.example
+++ b/.env.private_key.example
@@ -13,3 +13,7 @@ SNOWFLAKE_ROLE=your_role
 
 # Private Key Authentication Parameters
 SNOWFLAKE_PRIVATE_KEY_PATH=/absolute/path/to/your/private_key.p8
+
+# Connection Pooling Settings
+# Time interval in hours between automatic connection refreshes (default: 8)
+SNOWFLAKE_CONN_REFRESH_HOURS=8

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A Model Context Protocol (MCP) server for performing read-only operations agains
 - Flexible authentication to Snowflake using either:
   - Service account authentication with private key
   - External browser authentication for interactive sessions
+- Connection pooling with automatic background refresh to maintain persistent connections
 - Support for querying multiple views and databases in a single session
 - Support for multiple SQL statement types (SELECT, SHOW, DESCRIBE, EXPLAIN, WITH)
 - MCP-compatible handlers for querying Snowflake data
@@ -106,6 +107,18 @@ When using with Claude, you can ask questions like:
 - "Run this SQL query: SELECT customer_id, SUM(order_total) as total_spend FROM SALES.ORDERS GROUP BY customer_id ORDER BY total_spend DESC LIMIT 10"
 - "Query the MARKETING database to find the top 5 performing campaigns by conversion rate"
 - "Compare data from views in different databases by querying SALES.CUSTOMER_METRICS and MARKETING.CAMPAIGN_RESULTS"
+
+### Configuration
+
+Connection pooling behavior can be configured through environment variables:
+
+- `SNOWFLAKE_CONN_REFRESH_HOURS`: Time interval in hours between connection refreshes (default: 8)
+
+Example `.env` configuration:
+```
+# Set connection to refresh every 4 hours
+SNOWFLAKE_CONN_REFRESH_HOURS=4
+```
 
 ## Authentication Methods
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ A Model Context Protocol (MCP) server for performing read-only operations agains
   - Service account authentication with private key
   - External browser authentication for interactive sessions
 - Support for querying multiple views and databases in a single session
+- Support for multiple SQL statement types (SELECT, SHOW, DESCRIBE, EXPLAIN, WITH)
 - MCP-compatible handlers for querying Snowflake data
 - Read-only operations with security checks to prevent data modification
 - Support for Python 3.12+
@@ -21,7 +22,7 @@ The server provides the following tools for querying Snowflake:
 - **list_views**: List all views in a specified database and schema
 - **describe_view**: Get detailed information about a specific view including columns and SQL definition
 - **query_view**: Query data from a view with an optional row limit
-- **execute_query**: Execute custom read-only SQL queries (SELECT only) with results formatted as markdown tables
+- **execute_query**: Execute custom read-only SQL queries (SELECT, SHOW, DESCRIBE, EXPLAIN, WITH) with results formatted as markdown tables
 
 ## Installation
 
@@ -127,7 +128,7 @@ This method opens a browser window for interactive authentication.
 ## Security Considerations
 
 This server:
-- Enforces read-only operations (only SELECT statements are allowed)
+- Enforces read-only operations (only SELECT, SHOW, DESCRIBE, EXPLAIN, and WITH statements are allowed)
 - Automatically adds LIMIT clauses to prevent large result sets
 - Uses secure authentication methods for connections to Snowflake
 - Validates inputs to prevent SQL injection

--- a/README.md
+++ b/README.md
@@ -4,7 +4,10 @@ A Model Context Protocol (MCP) server for performing read-only operations agains
 
 ## Features
 
-- Secure connection to Snowflake using service account authentication with private key
+- Flexible authentication to Snowflake using either:
+  - Service account authentication with private key
+  - External browser authentication for interactive sessions
+- Support for querying multiple views and databases in a single session
 - MCP-compatible handlers for querying Snowflake data
 - Read-only operations with security checks to prevent data modification
 - Support for Python 3.12+
@@ -25,7 +28,9 @@ The server provides the following tools for querying Snowflake:
 ### Prerequisites
 
 - Python 3.12 or higher
-- A Snowflake account with a configured service account (username + private key)
+- A Snowflake account with either:
+  - A configured service account (username + private key), or
+  - A regular user account for browser-based authentication
 - [uv](https://github.com/astral-sh/uv) package manager (recommended)
 
 ### Steps
@@ -41,16 +46,21 @@ The server provides the following tools for querying Snowflake:
    uv pip install -e .
    ```
 
-3. Create a `.env` file based on `.env.example` with your Snowflake credentials:
+3. Create a `.env` file with your Snowflake credentials:
+
+   Choose one of the provided example files based on your preferred authentication method:
+
+   **For private key authentication**:
    ```
-   SNOWFLAKE_ACCOUNT=youraccount.region
-   SNOWFLAKE_USER=your_service_account_username
-   SNOWFLAKE_PRIVATE_KEY_PATH=/absolute/path/to/your/rsa_key.p8
-   SNOWFLAKE_WAREHOUSE=your_warehouse
-   SNOWFLAKE_DATABASE=your_database
-   SNOWFLAKE_SCHEMA=your_schema
-   SNOWFLAKE_ROLE=your_role
+   cp .env.private_key.example .env
    ```
+   Then edit the `.env` file to set your Snowflake account details and path to your private key.
+
+   **For external browser authentication**:
+   ```
+   cp .env.browser.example .env
+   ```
+   Then edit the `.env` file to set your Snowflake account details.
 
 ## Usage
 
@@ -63,6 +73,8 @@ uv run snowflake-mcp
 ```
 
 This will start the stdio-based MCP server, which can be connected to Claude Desktop or any MCP client that supports stdio communication.
+
+When using external browser authentication, a browser window will automatically open prompting you to log in to your Snowflake account.
 
 ### Claude Desktop Integration
 
@@ -92,13 +104,32 @@ When using with Claude, you can ask questions like:
 - "Show me sample data from the REVENUE_BY_REGION view in the FINANCE database"
 - "Run this SQL query: SELECT customer_id, SUM(order_total) as total_spend FROM SALES.ORDERS GROUP BY customer_id ORDER BY total_spend DESC LIMIT 10"
 - "Query the MARKETING database to find the top 5 performing campaigns by conversion rate"
+- "Compare data from views in different databases by querying SALES.CUSTOMER_METRICS and MARKETING.CAMPAIGN_RESULTS"
+
+## Authentication Methods
+
+### Private Key Authentication
+
+This method uses a service account and private key for non-interactive authentication, ideal for automated processes.
+
+1. Create a key pair for your Snowflake user following [Snowflake documentation](https://docs.snowflake.com/en/user-guide/key-pair-auth)
+2. Set `SNOWFLAKE_AUTH_TYPE=private_key` in your `.env` file
+3. Provide the path to your private key in `SNOWFLAKE_PRIVATE_KEY_PATH`
+
+### External Browser Authentication
+
+This method opens a browser window for interactive authentication.
+
+1. Set `SNOWFLAKE_AUTH_TYPE=external_browser` in your `.env` file
+2. When you start the server, a browser window will open asking you to log in
+3. After authentication, the session will remain active for the duration specified by your Snowflake account settings
 
 ## Security Considerations
 
 This server:
 - Enforces read-only operations (only SELECT statements are allowed)
 - Automatically adds LIMIT clauses to prevent large result sets
-- Uses service account authentication for secure connections
+- Uses secure authentication methods for connections to Snowflake
 - Validates inputs to prevent SQL injection
 
 ⚠️ **Important**: Keep your `.env` file secure and never commit it to version control. The `.gitignore` file is configured to exclude it.
@@ -121,6 +152,12 @@ ruff check .
 
 ```
 ruff format .
+```
+
+### Running Tests
+
+```
+pytest
 ```
 
 ## Contributing

--- a/mcp_server_snowflake/main.py
+++ b/mcp_server_snowflake/main.py
@@ -25,7 +25,6 @@ from mcp_server_snowflake.utils.snowflake_conn import (
     AuthType,
     SnowflakeConfig,
     connection_manager,
-    get_snowflake_connection,
 )
 
 # Load environment variables from .env file
@@ -64,8 +63,6 @@ def init_connection_manager() -> None:
     """Initialize the connection manager with Snowflake config."""
     config = get_snowflake_config()
     connection_manager.initialize(config)
-    print(f"Initialized Snowflake connection manager (auth type: {config.auth_type})")
-    print(f"Connection refresh interval: {connection_manager._refresh_interval}")
 
 
 # Define MCP server
@@ -76,7 +73,7 @@ def create_server() -> Server:
 
     server: Server = Server(
         name="mcp-server-snowflake",
-        version="0.1.0",
+        version="0.2.0",
         instructions="MCP server for performing read-only operations against "
         "Snowflake.",
     )

--- a/mcp_server_snowflake/main.py
+++ b/mcp_server_snowflake/main.py
@@ -1,22 +1,21 @@
 """MCP server implementation for Snowflake.
 
 This module provides a Model Context Protocol (MCP) server that allows Claude
-to perform read-only operations against Snowflake databases. It connects to 
-Snowflake using service account authentication with a private key and exposes
-various tools for querying database metadata and data.
+to perform read-only operations against Snowflake databases. It connects to
+Snowflake using either service account authentication with a private key or
+external browser authentication. It exposes various tools for querying database
+metadata and data, including support for multi-view and multi-database queries.
 
 The server is designed to be used with Claude Desktop as an MCP server, providing
 Claude with secure, controlled access to Snowflake data for analysis and reporting.
 """
 
 import os
-from pathlib import Path
-from typing import Dict, List, Any
+from typing import Any, Dict, List, Optional, Sequence, Union
 
-import asyncio
 import anyio
-import mcp
 import mcp.types as mcp_types
+from dotenv import load_dotenv
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
 from mcp.server.models import InitializationOptions
@@ -26,6 +25,7 @@ import sqlglot
 from sqlglot.errors import ParseError
 
 from mcp_server_snowflake.utils.snowflake_conn import (
+    AuthType,
     SnowflakeConfig,
     get_snowflake_connection,
 )
@@ -37,36 +37,49 @@ load_dotenv()
 # Initialize Snowflake configuration from environment variables
 def get_snowflake_config() -> SnowflakeConfig:
     """Load Snowflake configuration from environment variables."""
-    return SnowflakeConfig(
+    auth_type_str = os.getenv("SNOWFLAKE_AUTH_TYPE", "private_key").lower()
+    auth_type = (
+        AuthType.PRIVATE_KEY
+        if auth_type_str == "private_key"
+        else AuthType.EXTERNAL_BROWSER
+    )
+
+    config = SnowflakeConfig(
         account=os.getenv("SNOWFLAKE_ACCOUNT", ""),
         user=os.getenv("SNOWFLAKE_USER", ""),
-        private_key_path=os.getenv("SNOWFLAKE_PRIVATE_KEY_PATH", ""),
+        auth_type=auth_type,
         warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
         database=os.getenv("SNOWFLAKE_DATABASE"),
         schema_name=os.getenv("SNOWFLAKE_SCHEMA"),
         role=os.getenv("SNOWFLAKE_ROLE"),
     )
 
+    # Only set private_key_path if using private key authentication
+    if auth_type == AuthType.PRIVATE_KEY:
+        config.private_key_path = os.getenv("SNOWFLAKE_PRIVATE_KEY_PATH", "")
+
+    return config
+
 
 # Define MCP server
 def create_server() -> Server:
     """Create and configure the MCP server."""
-    server = Server(
+    server: Server = Server(
         name="mcp-server-snowflake",
         version="0.1.0",
-        instructions="MCP server for performing read-only operations against Snowflake.",
+        instructions="MCP server for performing read-only operations against "
+        "Snowflake.",
     )
-
-    # TODO: Register handlers using the appropriate decorator pattern
-    # server.call_tool() etc.
 
     return server
 
 
 # Snowflake query handler functions
 async def handle_list_databases(
-    name: str, arguments: Dict[str, Any] | None
-) -> List[mcp_types.TextContent]:
+    name: str, arguments: Optional[Dict[str, Any]] = None
+) -> Sequence[
+    Union[mcp_types.TextContent, mcp_types.ImageContent, mcp_types.EmbeddedResource]
+]:
     """Tool handler to list all accessible Snowflake databases."""
     try:
         # Get Snowflake connection
@@ -89,7 +102,7 @@ async def handle_list_databases(
         return [
             mcp_types.TextContent(
                 type="text",
-                text=f"Available Snowflake databases:\n" + "\n".join(databases),
+                text="Available Snowflake databases:\n" + "\n".join(databases),
             )
         ]
 
@@ -102,8 +115,10 @@ async def handle_list_databases(
 
 
 async def handle_list_views(
-    name: str, arguments: Dict[str, Any] | None
-) -> List[mcp_types.TextContent]:
+    name: str, arguments: Optional[Dict[str, Any]] = None
+) -> Sequence[
+    Union[mcp_types.TextContent, mcp_types.ImageContent, mcp_types.EmbeddedResource]
+]:
     """Tool handler to list views in a specified database and schema."""
     try:
         # Get Snowflake connection
@@ -130,7 +145,15 @@ async def handle_list_views(
             # Get the current schema
             cursor = conn.cursor()
             cursor.execute("SELECT CURRENT_SCHEMA()")
-            schema = cursor.fetchone()[0]
+            schema_result = cursor.fetchone()
+            if schema_result:
+                schema = schema_result[0]
+            else:
+                return [
+                    mcp_types.TextContent(
+                        type="text", text="Error: Could not determine current schema"
+                    )
+                ]
 
         # Execute query to list views
         cursor = conn.cursor()
@@ -167,8 +190,10 @@ async def handle_list_views(
 
 
 async def handle_describe_view(
-    name: str, arguments: Dict[str, Any] | None
-) -> List[mcp_types.TextContent]:
+    name: str, arguments: Optional[Dict[str, Any]] = None
+) -> Sequence[
+    Union[mcp_types.TextContent, mcp_types.ImageContent, mcp_types.EmbeddedResource]
+]:
     """Tool handler to describe the structure of a view."""
     try:
         # Get Snowflake connection
@@ -195,8 +220,16 @@ async def handle_describe_view(
             # Get the current schema
             cursor = conn.cursor()
             cursor.execute("SELECT CURRENT_SCHEMA()")
-            schema = cursor.fetchone()[0]
-            full_view_name = f"{database}.{schema}.{view_name}"
+            schema_result = cursor.fetchone()
+            if schema_result:
+                schema = schema_result[0]
+                full_view_name = f"{database}.{schema}.{view_name}"
+            else:
+                return [
+                    mcp_types.TextContent(
+                        type="text", text="Error: Could not determine current schema"
+                    )
+                ]
 
         # Execute query to describe view
         cursor = conn.cursor()
@@ -212,7 +245,8 @@ async def handle_describe_view(
 
         # Get view definition
         cursor.execute(f"SELECT GET_DDL('VIEW', '{full_view_name}')")
-        view_ddl = cursor.fetchone()[0]
+        view_ddl_result = cursor.fetchone()
+        view_ddl = view_ddl_result[0] if view_ddl_result else "Definition not available"
 
         cursor.close()
         conn.close()
@@ -243,8 +277,10 @@ async def handle_describe_view(
 
 
 async def handle_query_view(
-    name: str, arguments: Dict[str, Any] | None
-) -> List[mcp_types.TextContent]:
+    name: str, arguments: Optional[Dict[str, Any]] = None
+) -> Sequence[
+    Union[mcp_types.TextContent, mcp_types.ImageContent, mcp_types.EmbeddedResource]
+]:
     """Tool handler to query data from a view with optional limit."""
     try:
         # Get Snowflake connection
@@ -256,7 +292,9 @@ async def handle_query_view(
         schema = arguments.get("schema") if arguments else None
         view_name = arguments.get("view_name") if arguments else None
         limit = (
-            arguments.get("limit", 10) if arguments else 10
+            int(arguments.get("limit", 10))
+            if arguments and arguments.get("limit") is not None
+            else 10
         )  # Default limit to 10 rows
 
         if not database or not view_name:
@@ -274,15 +312,25 @@ async def handle_query_view(
             # Get the current schema
             cursor = conn.cursor()
             cursor.execute("SELECT CURRENT_SCHEMA()")
-            schema = cursor.fetchone()[0]
-            full_view_name = f"{database}.{schema}.{view_name}"
+            schema_result = cursor.fetchone()
+            if schema_result:
+                schema = schema_result[0]
+                full_view_name = f"{database}.{schema}.{view_name}"
+            else:
+                return [
+                    mcp_types.TextContent(
+                        type="text", text="Error: Could not determine current schema"
+                    )
+                ]
 
         # Execute query to get data from view
         cursor = conn.cursor()
         cursor.execute(f"SELECT * FROM {full_view_name} LIMIT {limit}")
 
         # Get column names
-        column_names = [col[0] for col in cursor.description]
+        column_names = (
+            [col[0] for col in cursor.description] if cursor.description else []
+        )
 
         # Process results
         rows = cursor.fetchall()
@@ -325,8 +373,10 @@ async def handle_query_view(
 
 
 async def handle_execute_query(
-    name: str, arguments: Dict[str, Any] | None
-) -> List[mcp_types.TextContent]:
+    name: str, arguments: Optional[Dict[str, Any]] = None
+) -> Sequence[
+    Union[mcp_types.TextContent, mcp_types.ImageContent, mcp_types.EmbeddedResource]
+]:
     """Tool handler to execute read-only SQL queries against Snowflake."""
     try:
         # Get Snowflake connection
@@ -338,7 +388,9 @@ async def handle_execute_query(
         database = arguments.get("database") if arguments else None
         schema = arguments.get("schema") if arguments else None
         limit_rows = (
-            arguments.get("limit", 100) if arguments else 100
+            int(arguments.get("limit", 100))
+            if arguments and arguments.get("limit") is not None
+            else 100
         )  # Default limit to 100 rows
 
         if not query:
@@ -374,7 +426,11 @@ async def handle_execute_query(
         # Extract database and schema context info for logging/display
         context_cursor = conn.cursor()
         context_cursor.execute("SELECT CURRENT_DATABASE(), CURRENT_SCHEMA()")
-        current_db, current_schema = context_cursor.fetchone()
+        context_result = context_cursor.fetchone()
+        if context_result:
+            current_db, current_schema = context_result
+        else:
+            current_db, current_schema = "Unknown", "Unknown"
         context_cursor.close()
 
         # Ensure the query has a LIMIT clause to prevent large result sets
@@ -389,11 +445,13 @@ async def handle_execute_query(
         cursor.execute(query)
 
         # Get column names and types
-        column_names = [col[0] for col in cursor.description]
+        column_names = (
+            [col[0] for col in cursor.description] if cursor.description else []
+        )
 
         # Fetch only up to limit_rows
         rows = cursor.fetchmany(limit_rows)
-        row_count = len(rows)
+        row_count = len(rows) if rows else 0
 
         cursor.close()
         conn.close()
@@ -442,15 +500,19 @@ async def handle_execute_query(
 def run_stdio_server() -> None:
     """Run the MCP server using stdin/stdout for communication."""
 
-    async def run():
+    async def run() -> None:
         server = create_server()
 
         # Register all the Snowflake tools
         @server.call_tool()
         async def call_tool(
-            name: str, arguments: Dict[str, Any] | None
-        ) -> List[
-            mcp_types.TextContent | mcp_types.ImageContent | mcp_types.EmbeddedResource
+            name: str, arguments: Optional[Dict[str, Any]] = None
+        ) -> Sequence[
+            Union[
+                mcp_types.TextContent,
+                mcp_types.ImageContent,
+                mcp_types.EmbeddedResource,
+            ]
         ]:
             if name == "list_databases":
                 return await handle_list_databases(name, arguments)
@@ -576,8 +638,3 @@ def run_stdio_server() -> None:
             await server.run(read_stream, write_stream, init_options)
 
     anyio.run(run)
-
-
-# Main entrypoint when run directly
-if __name__ == "__main__":
-    run_stdio_server()

--- a/mcp_server_snowflake/main.py
+++ b/mcp_server_snowflake/main.py
@@ -5,10 +5,6 @@ to perform read-only operations against Snowflake databases. It connects to
 Snowflake using either service account authentication with a private key or
 external browser authentication. It exposes various tools for querying database
 metadata and data, including support for multi-view and multi-database queries.
-to perform read-only operations against Snowflake databases. It connects to
-Snowflake using either service account authentication with a private key or
-external browser authentication. It exposes various tools for querying database
-metadata and data, including support for multi-view and multi-database queries.
 
 The server is designed to be used with Claude Desktop as an MCP server, providing
 Claude with secure, controlled access to Snowflake data for analysis and reporting.
@@ -16,22 +12,16 @@ Claude with secure, controlled access to Snowflake data for analysis and reporti
 
 import os
 from typing import Any, Dict, List, Optional, Sequence, Union
-from typing import Any, Dict, List, Optional, Sequence, Union
 
 import anyio
 import mcp.types as mcp_types
-from dotenv import load_dotenv
+import sqlglot
 from dotenv import load_dotenv
 from mcp.server import Server
 from mcp.server.stdio import stdio_server
-from mcp.server.models import InitializationOptions
-from mcp.server.lowlevel import NotificationOptions
-from dotenv import load_dotenv
-import sqlglot
 from sqlglot.errors import ParseError
 
 from mcp_server_snowflake.utils.snowflake_conn import (
-    AuthType,
     AuthType,
     SnowflakeConfig,
     get_snowflake_connection,
@@ -52,17 +42,8 @@ def get_snowflake_config() -> SnowflakeConfig:
     )
 
     config = SnowflakeConfig(
-    auth_type_str = os.getenv("SNOWFLAKE_AUTH_TYPE", "private_key").lower()
-    auth_type = (
-        AuthType.PRIVATE_KEY
-        if auth_type_str == "private_key"
-        else AuthType.EXTERNAL_BROWSER
-    )
-
-    config = SnowflakeConfig(
         account=os.getenv("SNOWFLAKE_ACCOUNT", ""),
         user=os.getenv("SNOWFLAKE_USER", ""),
-        auth_type=auth_type,
         auth_type=auth_type,
         warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
         database=os.getenv("SNOWFLAKE_DATABASE"),
@@ -76,22 +57,13 @@ def get_snowflake_config() -> SnowflakeConfig:
 
     return config
 
-    # Only set private_key_path if using private key authentication
-    if auth_type == AuthType.PRIVATE_KEY:
-        config.private_key_path = os.getenv("SNOWFLAKE_PRIVATE_KEY_PATH", "")
-
-    return config
-
 
 # Define MCP server
 def create_server() -> Server:
     """Create and configure the MCP server."""
     server: Server = Server(
-    server: Server = Server(
         name="mcp-server-snowflake",
         version="0.1.0",
-        instructions="MCP server for performing read-only operations against "
-        "Snowflake.",
         instructions="MCP server for performing read-only operations against "
         "Snowflake.",
     )
@@ -101,10 +73,6 @@ def create_server() -> Server:
 
 # Snowflake query handler functions
 async def handle_list_databases(
-    name: str, arguments: Optional[Dict[str, Any]] = None
-) -> Sequence[
-    Union[mcp_types.TextContent, mcp_types.ImageContent, mcp_types.EmbeddedResource]
-]:
     name: str, arguments: Optional[Dict[str, Any]] = None
 ) -> Sequence[
     Union[mcp_types.TextContent, mcp_types.ImageContent, mcp_types.EmbeddedResource]
@@ -132,7 +100,6 @@ async def handle_list_databases(
             mcp_types.TextContent(
                 type="text",
                 text="Available Snowflake databases:\n" + "\n".join(databases),
-                text="Available Snowflake databases:\n" + "\n".join(databases),
             )
         ]
 
@@ -145,10 +112,6 @@ async def handle_list_databases(
 
 
 async def handle_list_views(
-    name: str, arguments: Optional[Dict[str, Any]] = None
-) -> Sequence[
-    Union[mcp_types.TextContent, mcp_types.ImageContent, mcp_types.EmbeddedResource]
-]:
     name: str, arguments: Optional[Dict[str, Any]] = None
 ) -> Sequence[
     Union[mcp_types.TextContent, mcp_types.ImageContent, mcp_types.EmbeddedResource]
@@ -179,15 +142,6 @@ async def handle_list_views(
             # Get the current schema
             cursor = conn.cursor()
             cursor.execute("SELECT CURRENT_SCHEMA()")
-            schema_result = cursor.fetchone()
-            if schema_result:
-                schema = schema_result[0]
-            else:
-                return [
-                    mcp_types.TextContent(
-                        type="text", text="Error: Could not determine current schema"
-                    )
-                ]
             schema_result = cursor.fetchone()
             if schema_result:
                 schema = schema_result[0]
@@ -237,10 +191,6 @@ async def handle_describe_view(
 ) -> Sequence[
     Union[mcp_types.TextContent, mcp_types.ImageContent, mcp_types.EmbeddedResource]
 ]:
-    name: str, arguments: Optional[Dict[str, Any]] = None
-) -> Sequence[
-    Union[mcp_types.TextContent, mcp_types.ImageContent, mcp_types.EmbeddedResource]
-]:
     """Tool handler to describe the structure of a view."""
     try:
         # Get Snowflake connection
@@ -277,16 +227,6 @@ async def handle_describe_view(
                         type="text", text="Error: Could not determine current schema"
                     )
                 ]
-            schema_result = cursor.fetchone()
-            if schema_result:
-                schema = schema_result[0]
-                full_view_name = f"{database}.{schema}.{view_name}"
-            else:
-                return [
-                    mcp_types.TextContent(
-                        type="text", text="Error: Could not determine current schema"
-                    )
-                ]
 
         # Execute query to describe view
         cursor = conn.cursor()
@@ -302,8 +242,6 @@ async def handle_describe_view(
 
         # Get view definition
         cursor.execute(f"SELECT GET_DDL('VIEW', '{full_view_name}')")
-        view_ddl_result = cursor.fetchone()
-        view_ddl = view_ddl_result[0] if view_ddl_result else "Definition not available"
         view_ddl_result = cursor.fetchone()
         view_ddl = view_ddl_result[0] if view_ddl_result else "Definition not available"
 
@@ -340,10 +278,6 @@ async def handle_query_view(
 ) -> Sequence[
     Union[mcp_types.TextContent, mcp_types.ImageContent, mcp_types.EmbeddedResource]
 ]:
-    name: str, arguments: Optional[Dict[str, Any]] = None
-) -> Sequence[
-    Union[mcp_types.TextContent, mcp_types.ImageContent, mcp_types.EmbeddedResource]
-]:
     """Tool handler to query data from a view with optional limit."""
     try:
         # Get Snowflake connection
@@ -355,9 +289,6 @@ async def handle_query_view(
         schema = arguments.get("schema") if arguments else None
         view_name = arguments.get("view_name") if arguments else None
         limit = (
-            int(arguments.get("limit", 10))
-            if arguments and arguments.get("limit") is not None
-            else 10
             int(arguments.get("limit", 10))
             if arguments and arguments.get("limit") is not None
             else 10
@@ -388,25 +319,12 @@ async def handle_query_view(
                         type="text", text="Error: Could not determine current schema"
                     )
                 ]
-            schema_result = cursor.fetchone()
-            if schema_result:
-                schema = schema_result[0]
-                full_view_name = f"{database}.{schema}.{view_name}"
-            else:
-                return [
-                    mcp_types.TextContent(
-                        type="text", text="Error: Could not determine current schema"
-                    )
-                ]
 
         # Execute query to get data from view
         cursor = conn.cursor()
         cursor.execute(f"SELECT * FROM {full_view_name} LIMIT {limit}")
 
         # Get column names
-        column_names = (
-            [col[0] for col in cursor.description] if cursor.description else []
-        )
         column_names = (
             [col[0] for col in cursor.description] if cursor.description else []
         )
@@ -456,10 +374,6 @@ async def handle_execute_query(
 ) -> Sequence[
     Union[mcp_types.TextContent, mcp_types.ImageContent, mcp_types.EmbeddedResource]
 ]:
-    name: str, arguments: Optional[Dict[str, Any]] = None
-) -> Sequence[
-    Union[mcp_types.TextContent, mcp_types.ImageContent, mcp_types.EmbeddedResource]
-]:
     """Tool handler to execute read-only SQL queries against Snowflake."""
     try:
         # Get Snowflake connection
@@ -471,9 +385,6 @@ async def handle_execute_query(
         database = arguments.get("database") if arguments else None
         schema = arguments.get("schema") if arguments else None
         limit_rows = (
-            int(arguments.get("limit", 100))
-            if arguments and arguments.get("limit") is not None
-            else 100
             int(arguments.get("limit", 100))
             if arguments and arguments.get("limit") is not None
             else 100
@@ -489,17 +400,27 @@ async def handle_execute_query(
         # Validate that the query is read-only
         try:
             parsed_statements = sqlglot.parse(query, dialect="snowflake")
-            read_only_types = {'select', 'show', 'describe', 'explain', 'with'}
+            read_only_types = {"select", "show", "describe", "explain", "with"}
+
+            if not parsed_statements:
+                raise ParseError("Error: Could not parse SQL query")
 
             for stmt in parsed_statements:
-                if stmt.key.lower() not in read_only_types:
-                    raise ParseError(f"Error: Only read-only queries are allowed. Found statement type: {stmt.key}")
+                if (
+                    stmt is not None
+                    and hasattr(stmt, "key")
+                    and stmt.key
+                    and stmt.key.lower() not in read_only_types
+                ):
+                    raise ParseError(
+                        f"Error: Only read-only queries are allowed. Found statement type: {stmt.key}"
+                    )
 
-        except ParseError:
+        except ParseError as e:
             return [
                 mcp_types.TextContent(
                     type="text",
-                    text="Error: Only SELECT queries are allowed for security reasons",
+                    text=f"Error: Only SELECT/SHOW/DESCRIBE/EXPLAIN/WITH queries are allowed for security reasons. {str(e)}",
                 )
             ]
 
@@ -517,18 +438,13 @@ async def handle_execute_query(
             current_db, current_schema = context_result
         else:
             current_db, current_schema = "Unknown", "Unknown"
-        context_result = context_cursor.fetchone()
-        if context_result:
-            current_db, current_schema = context_result
-        else:
-            current_db, current_schema = "Unknown", "Unknown"
         context_cursor.close()
 
         # Ensure the query has a LIMIT clause to prevent large result sets
         # Parse the query to check if it already has a LIMIT
         if "LIMIT " not in query.upper():
             # Remove any trailing semicolon before adding the LIMIT clause
-            query = query.rstrip().rstrip(';')
+            query = query.rstrip().rstrip(";")
             query = f"{query} LIMIT {limit_rows};"
 
         # Execute the query
@@ -539,13 +455,9 @@ async def handle_execute_query(
         column_names = (
             [col[0] for col in cursor.description] if cursor.description else []
         )
-        column_names = (
-            [col[0] for col in cursor.description] if cursor.description else []
-        )
 
         # Fetch only up to limit_rows
         rows = cursor.fetchmany(limit_rows)
-        row_count = len(rows) if rows else 0
         row_count = len(rows) if rows else 0
 
         cursor.close()
@@ -596,19 +508,11 @@ def run_stdio_server() -> None:
     """Run the MCP server using stdin/stdout for communication."""
 
     async def run() -> None:
-    async def run() -> None:
         server = create_server()
 
         # Register all the Snowflake tools
         @server.call_tool()
         async def call_tool(
-            name: str, arguments: Optional[Dict[str, Any]] = None
-        ) -> Sequence[
-            Union[
-                mcp_types.TextContent,
-                mcp_types.ImageContent,
-                mcp_types.EmbeddedResource,
-            ]
             name: str, arguments: Optional[Dict[str, Any]] = None
         ) -> Sequence[
             Union[
@@ -715,7 +619,7 @@ def run_stdio_server() -> None:
                         "properties": {
                             "query": {
                                 "type": "string",
-                                "description": "The SQL query to execute (must be a SELECT statement)",
+                                "description": "The SQL query to execute (supports SELECT, SHOW, DESCRIBE, EXPLAIN, and WITH statements)",
                             },
                             "database": {
                                 "type": "string",

--- a/mcp_server_snowflake/utils/snowflake_conn.py
+++ b/mcp_server_snowflake/utils/snowflake_conn.py
@@ -7,11 +7,16 @@ connecting to Snowflake databases.
 
 The primary components are:
 - SnowflakeConfig: A Pydantic model that validates connection parameters
+- SnowflakeConnectionManager: A singleton class that manages persistent connections
 - load_private_key: A function to securely load RSA private keys
 - get_snowflake_connection: A function that establishes connections using key pair
   auth or browser auth
 """
 
+import os
+import threading
+import time
+from datetime import datetime, timedelta
 from enum import Enum
 from typing import Any, Dict, Optional
 
@@ -71,6 +76,107 @@ def load_private_key(private_key_path: str) -> rsa.RSAPrivateKey:
         return p_key
 
 
+class SnowflakeConnectionManager:
+    """Singleton manager for Snowflake connection pooling and refresh.
+
+    This class maintains a persistent connection to Snowflake and refreshes it
+    periodically in the background based on the configured refresh interval.
+    """
+
+    _instance = None
+    _lock = threading.Lock()
+
+    def __new__(cls):
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super(SnowflakeConnectionManager, cls).__new__(cls)
+                cls._instance._initialized = False
+            return cls._instance
+
+    def __init__(self):
+        """Initialize the connection manager if not already initialized."""
+        if self._initialized:
+            return
+
+        self._connection = None
+        self._connection_lock = threading.Lock()
+        self._config = None
+        self._last_refresh_time = None
+        self._refresh_thread = None
+        self._stop_event = threading.Event()
+
+        # Get refresh interval from environment variable (in hours, default 8)
+        refresh_interval_hours = float(os.getenv("SNOWFLAKE_CONN_REFRESH_HOURS", "8"))
+        self._refresh_interval = timedelta(hours=refresh_interval_hours)
+
+        self._initialized = True
+
+    def initialize(self, config: SnowflakeConfig) -> None:
+        """Initialize the connection manager with the given configuration."""
+        with self._connection_lock:
+            self._config = config
+            self._connect()
+
+            # Start background refresh thread if not already running
+            if self._refresh_thread is None or not self._refresh_thread.is_alive():
+                self._stop_event.clear()
+                self._refresh_thread = threading.Thread(
+                    target=self._refresh_connection_periodically,
+                    daemon=True
+                )
+                self._refresh_thread.start()
+
+    def get_connection(self) -> SnowflakeConnection:
+        """Get the current Snowflake connection, creating it if necessary."""
+        with self._connection_lock:
+            if self._connection is None:
+                if self._config is None:
+                    raise ValueError("Connection manager not initialized with a configuration")
+                self._connect()
+            return self._connection
+
+    def close(self) -> None:
+        """Close the current connection and stop the refresh thread."""
+        self._stop_event.set()
+
+        with self._connection_lock:
+            if self._connection is not None:
+                try:
+                    self._connection.close()
+                except Exception:
+                    pass  # Ignore errors during close
+                self._connection = None
+
+    def _connect(self) -> None:
+        """Establish a new connection to Snowflake."""
+        if self._connection is not None:
+            try:
+                self._connection.close()
+            except Exception:
+                pass  # Ignore errors during close
+
+        self._connection = get_snowflake_connection(self._config)
+        self._last_refresh_time = datetime.now()
+
+    def _refresh_connection_periodically(self) -> None:
+        """Background thread that refreshes the connection periodically."""
+        while not self._stop_event.is_set():
+            # Sleep for a short interval and check if it's time to refresh
+            if self._stop_event.wait(60):  # Check every minute
+                break
+
+            with self._connection_lock:
+                if (
+                    self._last_refresh_time is not None
+                    and datetime.now() - self._last_refresh_time >= self._refresh_interval
+                ):
+                    try:
+                        print(f"Refreshing Snowflake connection (interval: {self._refresh_interval})")
+                        self._connect()
+                    except Exception as e:
+                        print(f"Error refreshing Snowflake connection: {e}")
+
+
 def get_snowflake_connection(config: SnowflakeConfig) -> SnowflakeConnection:
     """Create a connection to Snowflake using key pair or external browser auth."""
     conn_params: Dict[str, Any] = {
@@ -86,12 +192,8 @@ def get_snowflake_connection(config: SnowflakeConfig) -> SnowflakeConnection:
             )
         private_key = load_private_key(config.private_key_path)
         conn_params["private_key"] = private_key
-        print(f"Using private key authentication for user {config.user}")
     elif config.auth_type == AuthType.EXTERNAL_BROWSER:
         conn_params["authenticator"] = "externalbrowser"
-        print(f"Using external browser authentication for user {config.user}")
-        # Add debug mode for troubleshooting
-        conn_params["debug"] = True
 
     # Add optional connection parameters
     if config.warehouse:
@@ -103,15 +205,8 @@ def get_snowflake_connection(config: SnowflakeConfig) -> SnowflakeConnection:
     if config.role:
         conn_params["role"] = config.role
 
-    try:
-        connection = snowflake.connector.connect(**conn_params)
-        print(f"Successfully connected to Snowflake account: {config.account}")
-        return connection
-    except Exception as e:
-        if config.auth_type == AuthType.EXTERNAL_BROWSER:
-            print(f"External browser authentication error: {str(e)}")
-            print("Make sure:")
-            print("1. You have a browser installed and accessible")
-            print("2. Your Snowflake account supports external browser authentication")
-            print("3. The snowflake-connector-python package is up to date")
-        raise
+    return snowflake.connector.connect(**conn_params)
+
+
+# Create a singleton instance for convenience
+connection_manager = SnowflakeConnectionManager()

--- a/mcp_server_snowflake/utils/snowflake_conn.py
+++ b/mcp_server_snowflake/utils/snowflake_conn.py
@@ -1,24 +1,33 @@
 """Snowflake connection utilities.
 
-This module provides utility functions and classes for establishing secure connections 
-to Snowflake using service account authentication with private key. It handles the 
-configuration parsing and security aspects of connecting to Snowflake databases.
+This module provides utility functions and classes for establishing secure connections
+to Snowflake using either service account authentication with private key or external
+browser authentication. It handles the configuration parsing and security aspects of
+connecting to Snowflake databases.
 
 The primary components are:
 - SnowflakeConfig: A Pydantic model that validates connection parameters
 - load_private_key: A function to securely load RSA private keys
-- get_snowflake_connection: A function that establishes connections using key pair auth
+- get_snowflake_connection: A function that establishes connections using key pair
+  auth or browser auth
 """
 
-import os
+from enum import Enum
 from typing import Any, Dict, Optional
 
 import snowflake.connector
 from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives.asymmetric import rsa
 from cryptography.hazmat.primitives.serialization import load_pem_private_key
-from pydantic import BaseModel
+from pydantic import BaseModel, ValidationInfo, field_validator
 from snowflake.connector import SnowflakeConnection
+
+
+class AuthType(str, Enum):
+    """Authentication types for Snowflake."""
+
+    PRIVATE_KEY = "private_key"
+    EXTERNAL_BROWSER = "external_browser"
 
 
 class SnowflakeConfig(BaseModel):
@@ -26,13 +35,27 @@ class SnowflakeConfig(BaseModel):
 
     account: str
     user: str
-    private_key_path: str
+    auth_type: AuthType
+    private_key_path: Optional[str] = None
     warehouse: Optional[str] = None
     database: Optional[str] = None
     schema_name: Optional[str] = (
         None  # Renamed from schema to avoid conflict with BaseModel
     )
     role: Optional[str] = None
+
+    @field_validator("private_key_path")
+    @classmethod
+    def validate_private_key_path(
+        cls, v: Optional[str], info: ValidationInfo
+    ) -> Optional[str]:
+        """Validate that private_key_path is provided when auth_type is PRIVATE_KEY."""
+        values = info.data
+        if values.get("auth_type") == AuthType.PRIVATE_KEY and not v:
+            raise ValueError(
+                "private_key_path is required when auth_type is PRIVATE_KEY"
+            )
+        return v
 
 
 def load_private_key(private_key_path: str) -> rsa.RSAPrivateKey:
@@ -49,15 +72,24 @@ def load_private_key(private_key_path: str) -> rsa.RSAPrivateKey:
 
 
 def get_snowflake_connection(config: SnowflakeConfig) -> SnowflakeConnection:
-    """Create a connection to Snowflake using key pair authentication."""
-    private_key = load_private_key(config.private_key_path)
-
+    """Create a connection to Snowflake using key pair or external browser auth."""
     conn_params: Dict[str, Any] = {
         "account": config.account,
         "user": config.user,
-        "private_key": private_key,
     }
 
+    # Set authentication parameters based on auth_type
+    if config.auth_type == AuthType.PRIVATE_KEY:
+        if not config.private_key_path:
+            raise ValueError(
+                "Private key path is required for private key authentication"
+            )
+        private_key = load_private_key(config.private_key_path)
+        conn_params["private_key"] = private_key
+    elif config.auth_type == AuthType.EXTERNAL_BROWSER:
+        conn_params["authenticator"] = "externalbrowser"
+
+    # Add optional connection parameters
     if config.warehouse:
         conn_params["warehouse"] = config.warehouse
     if config.database:

--- a/mcp_server_snowflake/utils/template.py
+++ b/mcp_server_snowflake/utils/template.py
@@ -9,112 +9,115 @@ from typing import Any, Dict, List
 
 import mcp.types as mcp_types
 
-from mcp_server_snowflake.utils.snowflake_conn import SnowflakeConfig, get_snowflake_connection
+from mcp_server_snowflake.main import get_snowflake_config
+from mcp_server_snowflake.utils.snowflake_conn import (
+    get_snowflake_connection,
+)
 
 
-async def template_simple_query(name: str, arguments: Dict[str, Any] | None) -> List[mcp_types.TextContent]:
+async def template_simple_query(
+    name: str, arguments: Dict[str, Any] | None
+) -> List[mcp_types.TextContent]:
     """Template for a simple SQL query that returns text results.
-    
-    Use this template for tools that execute a single SQL query and return 
+
+    Use this template for tools that execute a single SQL query and return
     formatted text results.
-    
+
     Args:
         name: The name of the tool being called
         arguments: The arguments provided to the tool
-        
+
     Returns:
         A list containing a single TextContent with the results
     """
     try:
         # Get Snowflake connection
-        config = get_snowflake_config()  # You'll need to import this function
+        config = get_snowflake_config()
         conn = get_snowflake_connection(config)
-        
+
         # Extract and validate arguments
         param1 = arguments.get("param1") if arguments else None
         param2 = arguments.get("param2") if arguments else None
-        
+
         if not param1:
-            return [mcp_types.TextContent(
-                type="text",
-                text="Error: param1 is required"
-            )]
-        
+            return [
+                mcp_types.TextContent(type="text", text="Error: param1 is required")
+            ]
+
         # Execute your SQL query
         cursor = conn.cursor()
         cursor.execute(f"YOUR SQL QUERY HERE WITH {param1} AND {param2}")
-        
+
         # Process results
         results = []
         for row in cursor:
             # Process each row as needed
             results.append(str(row))
-        
+
         cursor.close()
         conn.close()
-        
+
         # Return formatted content
-        return [mcp_types.TextContent(
-            type="text",
-            text=f"Results:\n" + "\n".join(results)
-        )]
-    
+        return [
+            mcp_types.TextContent(type="text", text="Results:\n" + "\n".join(results))
+        ]
+
     except Exception as e:
-        return [mcp_types.TextContent(
-            type="text",
-            text=f"Error executing query: {str(e)}"
-        )]
+        return [
+            mcp_types.TextContent(type="text", text=f"Error executing query: {str(e)}")
+        ]
 
 
-async def template_table_query(name: str, arguments: Dict[str, Any] | None) -> List[mcp_types.TextContent]:
+async def template_table_query(
+    name: str, arguments: Dict[str, Any] | None
+) -> List[mcp_types.TextContent]:
     """Template for a SQL query that returns formatted table results.
-    
-    Use this template for tools that execute a SQL query and return 
+
+    Use this template for tools that execute a SQL query and return
     results formatted as a markdown table.
-    
+
     Args:
         name: The name of the tool being called
         arguments: The arguments provided to the tool
-        
+
     Returns:
         A list containing a single TextContent with the results formatted as a table
     """
     try:
         # Get Snowflake connection
-        config = get_snowflake_config()  # You'll need to import this function
+        config = get_snowflake_config()
         conn = get_snowflake_connection(config)
-        
+
         # Extract and validate arguments
         param1 = arguments.get("param1") if arguments else None
         limit = arguments.get("limit", 10) if arguments else 10
-        
+
         if not param1:
-            return [mcp_types.TextContent(
-                type="text",
-                text="Error: param1 is required"
-            )]
-        
+            return [
+                mcp_types.TextContent(type="text", text="Error: param1 is required")
+            ]
+
         # Execute your SQL query
         cursor = conn.cursor()
         cursor.execute(f"YOUR SQL QUERY HERE WITH {param1} LIMIT {limit}")
-        
+
         # Get column names
         column_names = [col[0] for col in cursor.description]
-        
+
         # Process results
         rows = cursor.fetchall()
-        
+
         cursor.close()
         conn.close()
-        
+
         if rows:
             # Format the results as a markdown table
-            result = f"## Query Results\n\n"
-            
+            result = "## Query Results\n\n"
+
             # Create header row
             result += "| " + " | ".join(column_names) + " |\n"
             result += "| " + " | ".join(["---" for _ in column_names]) + " |\n"
-            
+
             # Add data rows
             for row in rows:
                 formatted_values = []
@@ -125,54 +128,49 @@ async def template_table_query(name: str, arguments: Dict[str, Any] | None) -> L
                         # Format the value as string and escape any pipe characters
                         formatted_values.append(str(val).replace("|", "\\|"))
                 result += "| " + " | ".join(formatted_values) + " |\n"
-            
-            return [mcp_types.TextContent(
-                type="text",
-                text=result
-            )]
+
+            return [mcp_types.TextContent(type="text", text=result)]
         else:
-            return [mcp_types.TextContent(
-                type="text",
-                text=f"No results found for the query."
-            )]
-    
+            return [
+                mcp_types.TextContent(
+                    type="text", text="No results found for the query."
+                )
+            ]
+
     except Exception as e:
-        return [mcp_types.TextContent(
-            type="text",
-            text=f"Error executing query: {str(e)}"
-        )]
+        return [
+            mcp_types.TextContent(type="text", text=f"Error executing query: {str(e)}")
+        ]
 
 
-def create_snowflake_tool_definition(name: str, description: str, parameters: Dict[str, Any]) -> mcp_types.Tool:
+def create_snowflake_tool_definition(
+    name: str, description: str, parameters: Dict[str, Any]
+) -> mcp_types.Tool:
     """Create a tool definition for a Snowflake query tool.
-    
+
     Args:
         name: The name of the tool
         description: A description of what the tool does
         parameters: A dictionary of parameters with their types and descriptions
-        
+
     Returns:
         A Tool object that can be added to the list_tools function
     """
     # Convert parameters to the schema format
     properties = {}
     required = []
-    
+
     for param_name, param_info in parameters.items():
         properties[param_name] = {
             "type": param_info.get("type", "string"),
-            "description": param_info.get("description", "")
+            "description": param_info.get("description", ""),
         }
-        
+
         if param_info.get("required", False):
             required.append(param_name)
-    
+
     return mcp_types.Tool(
         name=name,
         description=description,
-        inputSchema={
-            "type": "object",
-            "properties": properties,
-            "required": required
-        }
+        inputSchema={"type": "object", "properties": properties, "required": required},
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ target-version = "py312"
 
 [tool.ruff.lint]
 select = ["E", "F", "I"]
+ignore = ["E501"]  # Ignore line too long errors
 
 [tool.mypy]
 python_version = "3.12"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "mcp-server-snowflake"
-version = "0.1.0"
+version = "0.2.0"
 description = "MCP server for performing read-only operations against Snowflake"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/tests/test_snowflake_conn.py
+++ b/tests/test_snowflake_conn.py
@@ -1,15 +1,14 @@
 """Tests for Snowflake connection utilities."""
 
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest
 from cryptography.hazmat.primitives.asymmetric import rsa
 
 from mcp_server_snowflake.utils.snowflake_conn import (
+    AuthType,
     SnowflakeConfig,
     get_snowflake_connection,
-    load_private_key,
 )
 
 
@@ -20,12 +19,27 @@ def mock_private_key() -> rsa.RSAPrivateKey:
 
 
 @pytest.fixture
-def snowflake_config() -> SnowflakeConfig:
-    """Create a sample Snowflake configuration."""
+def snowflake_config_private_key() -> SnowflakeConfig:
+    """Create a sample Snowflake configuration with private key auth."""
     return SnowflakeConfig(
         account="testaccount",
         user="testuser",
+        auth_type=AuthType.PRIVATE_KEY,
         private_key_path="/path/to/key.p8",
+        warehouse="test_warehouse",
+        database="test_database",
+        schema_name="test_schema",
+        role="test_role",
+    )
+
+
+@pytest.fixture
+def snowflake_config_browser() -> SnowflakeConfig:
+    """Create a sample Snowflake configuration with external browser auth."""
+    return SnowflakeConfig(
+        account="testaccount",
+        user="testuser",
+        auth_type=AuthType.EXTERNAL_BROWSER,
         warehouse="test_warehouse",
         database="test_database",
         schema_name="test_schema",
@@ -35,30 +49,56 @@ def snowflake_config() -> SnowflakeConfig:
 
 @patch("mcp_server_snowflake.utils.snowflake_conn.load_private_key")
 @patch("snowflake.connector.connect")
-def test_get_snowflake_connection(
+def test_get_snowflake_connection_private_key(
     mock_connect: MagicMock,
     mock_load_key: MagicMock,
-    snowflake_config: SnowflakeConfig,
+    snowflake_config_private_key: SnowflakeConfig,
     mock_private_key: rsa.RSAPrivateKey,
 ) -> None:
-    """Test creating a Snowflake connection."""
+    """Test creating a Snowflake connection with private key auth."""
     # Setup mocks
     mock_load_key.return_value = mock_private_key
     mock_connection = MagicMock()
     mock_connect.return_value = mock_connection
 
     # Call function
-    conn = get_snowflake_connection(snowflake_config)
+    conn = get_snowflake_connection(snowflake_config_private_key)
 
     # Assertions
-    mock_load_key.assert_called_once_with(snowflake_config.private_key_path)
+    mock_load_key.assert_called_once_with(snowflake_config_private_key.private_key_path)
     mock_connect.assert_called_once_with(
-        account=snowflake_config.account,
-        user=snowflake_config.user,
+        account=snowflake_config_private_key.account,
+        user=snowflake_config_private_key.user,
         private_key=mock_private_key,
-        warehouse=snowflake_config.warehouse,
-        database=snowflake_config.database,
-        schema=snowflake_config.schema_name,
-        role=snowflake_config.role,
+        warehouse=snowflake_config_private_key.warehouse,
+        database=snowflake_config_private_key.database,
+        schema=snowflake_config_private_key.schema_name,
+        role=snowflake_config_private_key.role,
+    )
+    assert conn == mock_connection
+
+
+@patch("snowflake.connector.connect")
+def test_get_snowflake_connection_browser_auth(
+    mock_connect: MagicMock,
+    snowflake_config_browser: SnowflakeConfig,
+) -> None:
+    """Test creating a Snowflake connection with external browser auth."""
+    # Setup mocks
+    mock_connection = MagicMock()
+    mock_connect.return_value = mock_connection
+
+    # Call function
+    conn = get_snowflake_connection(snowflake_config_browser)
+
+    # Assertions
+    mock_connect.assert_called_once_with(
+        account=snowflake_config_browser.account,
+        user=snowflake_config_browser.user,
+        authenticator="externalbrowser",
+        warehouse=snowflake_config_browser.warehouse,
+        database=snowflake_config_browser.database,
+        schema=snowflake_config_browser.schema_name,
+        role=snowflake_config_browser.role,
     )
     assert conn == mock_connection

--- a/uv.lock
+++ b/uv.lock
@@ -261,7 +261,7 @@ wheels = [
 
 [[package]]
 name = "mcp-server-snowflake"
-version = "0.1.0"
+version = "0.2.0"
 source = { editable = "." }
 dependencies = [
     { name = "anyio" },


### PR DESCRIPTION
This pull request introduces flexible authentication methods for connecting to Snowflake, updates the documentation to reflect these changes, and refactors the connection management in the MCP server.

### Authentication Methods:
* [`.env.browser.example`](diffhunk://#diff-bdb07bb52ccb961e2b3239c1a21ee1caa321a55250b79115700803b8f2eaa060R1-R19): Added an example configuration file for external browser authentication.
* [`.env.private_key.example`](diffhunk://#diff-4be89d6a8a4be51bf9745d7a6425862ad2931fe6b761395b24e3fd5f589ffb52R1-R19): Added an example configuration file for private key authentication.
* [`.env.example`](diffhunk://#diff-a3046da0d15a27e89f2afe639b25748a7ad4d9290af3e7b1b6c1a5533c8f0a8cL1-L8): Removed the old Snowflake connection parameters.

### Documentation Updates:
* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R12): Updated to include instructions for both private key and external browser authentication, connection pooling settings, and enhanced security considerations. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L7-R12) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L21-R35) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L44-R65) [[4]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R79-R80) [[5]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R109-R146) [[6]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R171-R176)

### Code Refactoring:
* [`mcp_server_snowflake/main.py`](diffhunk://#diff-e5b568d0201e780c9b0a79c73c776a599c904a2489322319822f376f773a7524L5-R27): Refactored to support both authentication methods and updated connection management to use a connection manager for handling Snowflake connections. [[1]](diffhunk://#diff-e5b568d0201e780c9b0a79c73c776a599c904a2489322319822f376f773a7524L5-R27) [[2]](diffhunk://#diff-e5b568d0201e780c9b0a79c73c776a599c904a2489322319822f376f773a7524L40-R93) [[3]](diffhunk://#diff-e5b568d0201e780c9b0a79c73c776a599c904a2489322319822f376f773a7524L86-R111) [[4]](diffhunk://#diff-e5b568d0201e780c9b0a79c73c776a599c904a2489322319822f376f773a7524L105-R131) [[5]](diffhunk://#diff-e5b568d0201e780c9b0a79c73c776a599c904a2489322319822f376f773a7524L133-R161) [[6]](diffhunk://#diff-e5b568d0201e780c9b0a79c73c776a599c904a2489322319822f376f773a7524L147-R175) [[7]](diffhunk://#diff-e5b568d0201e780c9b0a79c73c776a599c904a2489322319822f376f773a7524L170-R205) [[8]](diffhunk://#diff-e5b568d0201e780c9b0a79c73c776a599c904a2489322319822f376f773a7524L198-R236) [[9]](diffhunk://#diff-e5b568d0201e780c9b0a79c73c776a599c904a2489322319822f376f773a7524L215-R256) [[10]](diffhunk://#diff-e5b568d0201e780c9b0a79c73c776a599c904a2489322319822f376f773a7524L246-R300) [[11]](diffhunk://#diff-e5b568d0201e780c9b0a79c73c776a599c904a2489322319822f376f773a7524L277-R342) [[12]](diffhunk://#diff-e5b568d0201e780c9b0a79c73c776a599c904a2489322319822f376f773a7524L328-R395)