### PR TITLE
Rename package from mcp-server-snowflake to snowflake-mcp-server

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ The server provides the following tools for querying Snowflake:
 
 1. Clone this repository:
    ```
-   git clone https://github.com/yourusername/mcp-server-snowflake.git
-   cd mcp-server-snowflake
+   git clone https://github.com/yourusername/snowflake-mcp-server.git
+   cd snowflake-mcp-server
    ```
 
 2. Install the package:
@@ -72,6 +72,9 @@ After installing the package, you can run the server directly with:
 
 ```
 uv run snowflake-mcp
+
+# Or you can be explicit about using stdio transport
+uv run snowflake-mcp-stdio
 ```
 
 This will start the stdio-based MCP server, which can be connected to Claude Desktop or any MCP client that supports stdio communication.
@@ -87,9 +90,23 @@ When using external browser authentication, a browser window will automatically 
       "command": "uv",
       "args": [
          "--directory",
-         "/<path-to-code>/mcp-server-snowflake",
+         "/<path-to-code>/snowflake-mcp-server",
          "run",
          "snowflake-mcp"
+      ]
+   }
+   ```
+   
+   Or explicitly specify the stdio transport:
+   
+   ```yaml
+   "snowflake-mcp-server": {
+      "command": "uv",
+      "args": [
+         "--directory",
+         "/<path-to-code>/snowflake-mcp-server",
+         "run",
+         "snowflake-mcp-stdio"
       ]
    }
    ```

--- a/mcp_server_snowflake/main.py
+++ b/mcp_server_snowflake/main.py
@@ -72,7 +72,7 @@ def create_server() -> Server:
     init_connection_manager()
 
     server: Server = Server(
-        name="mcp-server-snowflake",
+        name="snowflake-mcp-server",
         version="0.2.0",
         instructions="MCP server for performing read-only operations against "
         "Snowflake.",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "mcp-server-snowflake"
+name = "snowflake-mcp-server"
 version = "0.2.0"
 description = "MCP server for performing read-only operations against Snowflake"
 readme = "README.md"
@@ -21,6 +21,7 @@ dependencies = [
 
 [project.scripts]
 snowflake-mcp = "mcp_server_snowflake.main:run_stdio_server"
+snowflake-mcp-stdio = "mcp_server_snowflake.main:run_stdio_server"
 
 [project.optional-dependencies]
 dev = [


### PR DESCRIPTION
## Summary
- Updates package name in pyproject.toml to snowflake-mcp-server
- Adds explicit entry point for stdio transport (snowflake-mcp-stdio)
- Updates server name in main.py
- Updates README with new naming conventions and examples

This change prepares the codebase for future addition of SSE transport while maintaining backward compatibility with the original entry point.